### PR TITLE
Odd rows dataframe table

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -31,6 +31,7 @@ pre {
 ========================================== */
 
 /* Main tan color */
+.dataframe tbody tr:nth-child(odd),
 #terminal_list_header,
 .CodeMirror-scroll,
 .CodeMirror-gutter,


### PR DESCRIPTION
### Apply solarized light to dataframe tables

- Issue #1
- applying `background-color: #fdf6e3` odd rows to make dataframe table solarized light like.